### PR TITLE
Declare missing properties in `auth_plugin_anonymous`

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -22,6 +22,14 @@ class auth_plugin_anonymous extends auth_plugin_base
 
     const KEYNAME = "key"; // param to look for in the decoded url data
 
+    private string $FIRSTNAME;
+    private string $LASTNAME;
+    private string $EMAIL;
+    private string $COHORT;
+    private int $TIMEOUT;
+    private string $VALIDATOR;
+    private int $ROLE;
+
     /**
      * Constructor
      */
@@ -33,9 +41,9 @@ class auth_plugin_anonymous extends auth_plugin_base
         $this->LASTNAME = $this->config->lastname ?: "user";
         $this->EMAIL = $this->config->email ?: "anonymous@127.0.0.1";
         $this->COHORT = $this->config->cohort ?: "anonymous";
-        $this->TIMEOUT = intval($this->config->timeout) ?: 0;
+        $this->TIMEOUT = $this->config->timeout ?: 0;
         $this->VALIDATOR = $this->config->regex ?: '/./g';
-        $this->ROLE = $this->config->role ?: 0;
+        $this->ROLE = $this->config->assignrole ?: 0;
     }
 
     /**


### PR DESCRIPTION
As of [PHP 8.2](https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties), assigning properties dynamically causes a deprecation warning. To reproduce this specific problem, just set the following in your `config.php`:

```php
$CFG->debug = E_ALL;
$CFG->debugdisplay = 1;
```

And go to (for example) http://your.moodle/admin/settings.php?section=authsettinganonymous to see the notice:

> Creation of dynamic property auth_plugin_anonymous::$FIRSTNAME is deprecated

This Patch simply adds the missing declarations.

Also, since PHP will coerce values to the declared types of the class properties, the `intval` call becomes unnecessary.

---

Finally, unrelated to the previous issue, but too small for a separate PR:

There was a typo in the same constructor. Instead of `role` the desired config property is called `assignrole`. See line 97 here:

https://github.com/frumbert/auth_anonymous/blob/90c5aba69efc2881bd393b3108e94f1a39bcfc92/settings.php#L96-L103

---

With these changes, using the aforementioned debug configuration will no longer produce warnings/error messages.