### PR TITLE
fix invalid regex modifier for key validator

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -34,7 +34,7 @@ class auth_plugin_anonymous extends auth_plugin_base
         $this->EMAIL = $this->config->email ?: "anonymous@127.0.0.1";
         $this->COHORT = $this->config->cohort ?: "anonymous";
         $this->TIMEOUT = intval($this->config->timeout) ?: 0;
-        $this->VALIDATOR = $this->config->regex ?: '/./g';
+        $this->VALIDATOR = $this->config->regex ?: '/./'; // meaning "match any value"
         $this->ROLE = $this->config->role ?: 0;
     }
 
@@ -188,10 +188,9 @@ exit;
      * @return boolean
      */
     private function validate_key($key) {
-        if (empty($this->VALIDATOR)) $this->VALIDATOR = '/./'; // meaning "match any value"
         if (substr($this->VALIDATOR,0,1) !== '/') $this->VALIDATOR = '/'.$this->VALIDATOR;
         if (substr($this->VALIDATOR,-1,1) !== '/') $this->VALIDATOR = $this->VALIDATOR.'/';
-        return !empty(preg_grep($this->VALIDATOR, [$key]));
+        return preg_match($this->VALIDATOR, $key);
     }
 
     /**


### PR DESCRIPTION
The `g` modifier is not valid for `preg_grep` (or `preg_match`).

The default for `$VALIDATOR` set in the constructor is now `'/./'`. The `empty` check in the `validate_key` method is no longer needed.

Using `preg_match` is simpler and more readable.